### PR TITLE
Correctly detext java in -tid, don't double annotate.

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -302,7 +302,7 @@ while (defined($_ = <>)) {
 				# fall through to $tidy_java
 			}
 
-			if ($tidy_java and $pname eq "java") {
+			if ($tidy_java and $pname =~ m/^java/) {
 				# along with $tidy_generic, converts the following:
 				#	Lorg/mozilla/javascript/ContextFactory;.call(Lorg/mozilla/javascript/ContextAction;)Ljava/lang/Object;
 				#	Lorg/mozilla/javascript/ContextFactory;.call(Lorg/mozilla/javascript/C
@@ -325,11 +325,11 @@ while (defined($_ = <>)) {
 			# detect jit from the module name; eg:
 			#          7f722d142778 Ljava/io/PrintStream;::print (/tmp/perf-19982.map)
 			if (scalar(@inline) > 0) {
-				$func .= "_[i]";	# inlined
+				$func .= "_[i]" unless $func =~ m/.*.\_\[i\]/;	# inlined
 			} elsif ($annotate_kernel == 1 && $mod =~ m/(^\[|vmlinux$)/ && $mod !~ /unknown/) {
 				$func .= "_[k]";	# kernel
 			} elsif ($annotate_jit == 1 && $mod =~ m:/tmp/perf-\d+\.map:) {
-				$func .= "_[j]";	# jitted
+				$func .= "_[j]" unless $func =~ m/.*.\_\[j\]/;	# jitted
 			}
 			push @inline, $func;
 		}


### PR DESCRIPTION
Stackcollapse was detecting java programs correctly when profiling
the process, but failing when --tid was used. Switched to matching
start of string.
Also, auto annotation caused double annotation (discovered when
implementing perf-map-agent native annotation).