### PR TITLE
Improve java frame detection

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -377,8 +377,10 @@ sub color {
 			$type = "green";
 		} elsif ($name =~ m:_\[i\]$:) {	# inline annotation
 			$type = "aqua";
-		} elsif ($name =~ m:^L?(java|org|com|io|sun)/:) {	# Java
+		} elsif ($name =~ m:^L?(java|org|com|io|sun|jdk)/:) {	# Java
 			$type = "green";
+		} elsif ($name =~ /:::/) {      # Java, typical perf-map-agent method separator
+			$type = "green";	              
 		} elsif ($name =~ /::/) {	# C++
 			$type = "yellow";
 		} elsif ($name =~ m:_\[k\]$:) {	# kernel annotation


### PR DESCRIPTION
- Detect common perf-map-agent method separator ':::' (after stackcollapse-perf.pl tidyup replacing ';' with ':').
- Detect common prefix detection of 'jdk', which is a post jdk9 jdk package.